### PR TITLE
remove ^:figwheel-load annotation from core.cljs to fix js evaluation errors on figwheel reload

### DIFF
--- a/src/luno/android/core.cljs
+++ b/src/luno/android/core.cljs
@@ -1,4 +1,4 @@
-(ns ^:figwheel-load luno.android.core
+(ns luno.android.core
   (:require [reagent.core :as r :refer [atom]]
             [clojure.string :refer [blank?]]
             [re-frame.core :refer [subscribe dispatch dispatch-sync]]

--- a/src/luno/ios/core.cljs
+++ b/src/luno/ios/core.cljs
@@ -1,4 +1,4 @@
-(ns ^:figwheel-load luno.ios.core
+(ns luno.ios.core
   (:require [clojure.string :refer [blank?]]
             [reagent.core :as r]
             [re-frame.core :refer [subscribe dispatch dispatch-sync]]


### PR DESCRIPTION
- force reloading core.cljs is not needed anymore and is wrong because both core.cljs files (ios and android) are evaluated. This causes evaluation errors when platform specific code is evaluated on wrong platform.
- this change will be included in next version of re-natal
